### PR TITLE
Implement Flattened JWS serialization for Veramo compatibility

### DIFF
--- a/tap-agent/Cargo.toml
+++ b/tap-agent/Cargo.toml
@@ -33,6 +33,7 @@ tempfile = { version = "3.8", optional = true }
 # Crypto backends (optional)
 ed25519-dalek = { version = "2.2", features = ["rand_core"], optional = true }
 curve25519-dalek = { version = "4.1", features = ["digest"], optional = true }
+x25519-dalek = { version = "2.0", features = ["static_secrets"], optional = true }
 p256 = { version = "0.13", features = ["ecdh", "ecdsa"], optional = true }
 k256 = { version = "0.13", features = ["ecdsa"], optional = true }
 rand = { version = "0.8", optional = true }
@@ -86,6 +87,6 @@ wasm = [
 ]
 
 # Crypto features
-crypto-ed25519 = ["dep:ed25519-dalek", "dep:curve25519-dalek", "dep:rand"]
+crypto-ed25519 = ["dep:ed25519-dalek", "dep:curve25519-dalek", "dep:x25519-dalek", "dep:rand"]
 crypto-p256 = ["dep:p256", "dep:rand"]
 crypto-secp256k1 = ["dep:k256", "dep:rand"]

--- a/tap-agent/src/agent.rs
+++ b/tap-agent/src/agent.rs
@@ -1466,8 +1466,8 @@ impl crate::agent::Agent for TapAgent {
         // Check if it's an encrypted message (JWE) or signed message (JWS)
         let is_encrypted =
             json_value.get("protected").is_some() && json_value.get("recipients").is_some();
-        let is_signed =
-            json_value.get("payload").is_some() && json_value.get("signatures").is_some();
+        let is_signed = json_value.get("payload").is_some()
+            && (json_value.get("signatures").is_some() || json_value.get("signature").is_some());
 
         debug!(
             "Message type detection: encrypted={}, signed={}",

--- a/tap-agent/src/agent_key_manager.rs
+++ b/tap-agent/src/agent_key_manager.rs
@@ -724,7 +724,42 @@ impl KeyManager for AgentKeyManager {
             return Ok(verification_key);
         }
 
-        // In a full implementation, we would use a DID Resolver here
+        // Resolve did:key DIDs directly from the DID string (public key is embedded)
+        let did = kid.split('#').next().unwrap_or(kid);
+        if did.starts_with("did:key:") {
+            let resolver = crate::did::KeyResolver::new();
+            #[cfg(not(target_arch = "wasm32"))]
+            let did_doc_result = {
+                use crate::did::DIDMethodResolver;
+                resolver.resolve_method(did).await
+            };
+            #[cfg(target_arch = "wasm32")]
+            let did_doc_result = {
+                use crate::did::WasmDIDMethodResolver;
+                resolver.resolve_method(did)
+            };
+
+            if let Ok(Some(did_doc)) = did_doc_result {
+                // Find the verification method matching the kid
+                if let Some(vm) = did_doc.verification_method.iter().find(|vm| vm.id == kid) {
+                    if let Ok(vk) = PublicVerificationKey::from_verification_material(
+                        kid.to_string(),
+                        &vm.verification_material,
+                    ) {
+                        let verification_key =
+                            Arc::new(vk) as Arc<dyn VerificationKey + Send + Sync>;
+
+                        // Cache for future lookups
+                        if let Ok(mut verification_keys) = self.verification_keys.write() {
+                            verification_keys.insert(kid.to_string(), verification_key.clone());
+                        }
+
+                        return Ok(verification_key);
+                    }
+                }
+            }
+        }
+
         Err(Error::Cryptography(format!(
             "No verification key found with ID: {}",
             kid

--- a/tap-agent/src/key_manager.rs
+++ b/tap-agent/src/key_manager.rs
@@ -9,7 +9,6 @@ use crate::local_agent_key::{LocalAgentKey, PublicVerificationKey};
 use crate::message_packing::{KeyManagerPacking, MessageError};
 
 use async_trait::async_trait;
-use base64::Engine;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -621,7 +620,40 @@ impl KeyManager for DefaultKeyManager {
             return Ok(verification_key);
         }
 
-        // In a real implementation, we would use a DID Resolver here
+        // Resolve did:key DIDs directly from the DID string (public key is embedded)
+        let did = kid.split('#').next().unwrap_or(kid);
+        if did.starts_with("did:key:") {
+            let resolver = crate::did::KeyResolver::new();
+            #[cfg(not(target_arch = "wasm32"))]
+            let did_doc_result = {
+                use crate::did::DIDMethodResolver;
+                resolver.resolve_method(did).await
+            };
+            #[cfg(target_arch = "wasm32")]
+            let did_doc_result = {
+                use crate::did::WasmDIDMethodResolver;
+                resolver.resolve_method(did)
+            };
+
+            if let Ok(Some(did_doc)) = did_doc_result {
+                if let Some(vm) = did_doc.verification_method.iter().find(|vm| vm.id == kid) {
+                    if let Ok(vk) = PublicVerificationKey::from_verification_material(
+                        kid.to_string(),
+                        &vm.verification_material,
+                    ) {
+                        let verification_key =
+                            Arc::new(vk) as Arc<dyn VerificationKey + Send + Sync>;
+
+                        if let Ok(mut verification_keys) = self.verification_keys.write() {
+                            verification_keys.insert(kid.to_string(), verification_key.clone());
+                        }
+
+                        return Ok(verification_key);
+                    }
+                }
+            }
+        }
+
         Err(Error::Cryptography(format!(
             "No verification key found with ID: {}",
             kid
@@ -679,9 +711,8 @@ impl KeyManager for DefaultKeyManager {
             .ok_or_else(|| Error::Cryptography("No kid found in JWS signature".to_string()))?;
         let verification_key = KeyManager::resolve_verification_key(self, &kid).await?;
 
-        // Decode the signature
-        let signature_bytes = base64::engine::general_purpose::STANDARD
-            .decode(&signature.signature)
+        // Decode the signature (accept both base64 and base64url)
+        let signature_bytes = crate::message::base64_decode_flexible(&signature.signature)
             .map_err(|e| Error::Cryptography(format!("Failed to decode signature: {}", e)))?;
 
         // Create the signing input (protected.payload)
@@ -699,9 +730,8 @@ impl KeyManager for DefaultKeyManager {
             ));
         }
 
-        // Decode the payload
-        let payload_bytes = base64::engine::general_purpose::STANDARD
-            .decode(&jws.payload)
+        // Decode the payload (accept both base64 and base64url)
+        let payload_bytes = crate::message::base64_decode_flexible(&jws.payload)
             .map_err(|e| Error::Cryptography(format!("Failed to decode payload: {}", e)))?;
 
         Ok(payload_bytes)

--- a/tap-agent/src/local_agent_key.rs
+++ b/tap-agent/src/local_agent_key.rs
@@ -209,6 +209,7 @@ impl LocalAgentKey {
             let protected = protected_header.unwrap_or_else(|| crate::message::JweProtected {
                 epk: ephemeral_key,
                 apv: apv_b64.clone(),
+                apu: String::new(),
                 typ: crate::message::DIDCOMM_ENCRYPTED.to_string(),
                 enc: "A256GCM".to_string(),
                 alg: "ECDH-ES+A256KW".to_string(),
@@ -983,6 +984,7 @@ impl EncryptionKey for LocalAgentKey {
             JweProtected {
                 epk: ephemeral_key,
                 apv: base64::engine::general_purpose::STANDARD.encode(Uuid::new_v4().as_bytes()),
+                apu: String::new(),
                 typ: crate::message::DIDCOMM_ENCRYPTED.to_string(),
                 enc: enc.as_str().to_string(),
                 alg: alg.as_str().to_string(),
@@ -1162,148 +1164,166 @@ impl DecryptionKey for LocalAgentKey {
     }
 
     async fn unwrap_jwe(&self, jwe: &Jwe) -> Result<Vec<u8>> {
-        #[cfg(feature = "crypto-p256")]
-        {
-            // 1. Find the recipient that matches our key ID
-            let recipient = jwe
-                .recipients
-                .iter()
-                .find(|r| r.header.kid == crate::agent_key::AgentKey::key_id(self))
-                .ok_or_else(|| {
-                    Error::Cryptography(format!(
-                        "No matching recipient found for key ID: {}",
-                        crate::agent_key::AgentKey::key_id(self)
-                    ))
-                })?;
+        let our_kid = crate::agent_key::AgentKey::key_id(self);
 
-            // 2. Decode and parse the protected header to get the EPK
-            let protected_bytes = base64::engine::general_purpose::STANDARD
-                .decode(&jwe.protected)
-                .map_err(|e| {
-                    Error::Cryptography(format!("Failed to decode protected header: {}", e))
-                })?;
-
-            let protected: JweProtected =
-                serde_json::from_slice(&protected_bytes).map_err(|e| {
-                    Error::Cryptography(format!("Failed to parse protected header: {}", e))
-                })?;
-
-            // 3. Decode the JWE elements
-            let ciphertext = base64::engine::general_purpose::STANDARD
-                .decode(&jwe.ciphertext)
-                .map_err(|e| Error::Cryptography(format!("Failed to decode ciphertext: {}", e)))?;
-
-            let wrapped_cek = base64::engine::general_purpose::STANDARD
-                .decode(&recipient.encrypted_key)
-                .map_err(|e| {
-                    Error::Cryptography(format!("Failed to decode encrypted key: {}", e))
-                })?;
-
-            let iv = base64::engine::general_purpose::STANDARD
-                .decode(&jwe.iv)
-                .map_err(|e| Error::Cryptography(format!("Failed to decode IV: {}", e)))?;
-
-            let tag = base64::engine::general_purpose::STANDARD
-                .decode(&jwe.tag)
-                .map_err(|e| Error::Cryptography(format!("Failed to decode tag: {}", e)))?;
-
-            // 4. Extract EPK coordinates and reconstruct the public key
-            let (epk_x_b64, epk_y_b64) = match &protected.epk {
-                EphemeralPublicKey::Ec { x, y, .. } => (x.clone(), y.clone()),
-                _ => {
-                    return Err(Error::Cryptography(
-                        "Unsupported EPK type for P-256 decryption".to_string(),
-                    ))
-                }
-            };
-
-            let epk_x = base64::engine::general_purpose::STANDARD
-                .decode(&epk_x_b64)
-                .map_err(|e| Error::Cryptography(format!("Failed to decode EPK x: {}", e)))?;
-            let epk_y = base64::engine::general_purpose::STANDARD
-                .decode(&epk_y_b64)
-                .map_err(|e| Error::Cryptography(format!("Failed to decode EPK y: {}", e)))?;
-
-            // Reconstruct the EPK as an uncompressed point
-            let mut epk_point_bytes = vec![0x04]; // Uncompressed point format
-            epk_point_bytes.extend_from_slice(&epk_x);
-            epk_point_bytes.extend_from_slice(&epk_y);
-
-            let epk_encoded_point = P256EncodedPoint::from_bytes(&epk_point_bytes)
-                .map_err(|e| Error::Cryptography(format!("Invalid EPK point: {}", e)))?;
-
-            let epk_public_key = P256PublicKey::from_encoded_point(&epk_encoded_point);
-            if epk_public_key.is_none().into() {
-                return Err(Error::Cryptography("Invalid EPK public key".to_string()));
-            }
-            let epk_public_key = epk_public_key.unwrap();
-
-            // 5. Get our private key and perform ECDH
-            let jwk = self.private_key_jwk()?;
-            let d_b64 = jwk
-                .get("d")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| Error::Cryptography("Missing private key (d) in JWK".to_string()))?;
-
-            let d_bytes = base64::engine::general_purpose::STANDARD
-                .decode(d_b64)
-                .map_err(|e| Error::Cryptography(format!("Failed to decode private key: {}", e)))?;
-
-            // Create our secret key from the d value
-            let secret_key = p256::SecretKey::from_bytes((&d_bytes[..]).into())
-                .map_err(|e| Error::Cryptography(format!("Invalid private key: {}", e)))?;
-
-            // Perform ECDH
-            let shared_secret = p256::ecdh::diffie_hellman(
-                secret_key.to_nonzero_scalar(),
-                epk_public_key.as_affine(),
-            );
-            let shared_bytes = shared_secret.raw_secret_bytes();
-
-            // 6. Derive KEK using Concat KDF
-            let apv = base64::engine::general_purpose::STANDARD
-                .decode(&protected.apv)
-                .unwrap_or_default();
-
-            let kek = crate::crypto::derive_key_ecdh_es(
-                shared_bytes.as_slice(),
-                b"", // apu - empty for anonymous sender
-                &apv,
-                256,
-            )?;
-
-            // 7. Unwrap CEK using AES-KW
-            let mut kek_array = [0u8; 32];
-            kek_array.copy_from_slice(&kek);
-            let cek = crate::crypto::unwrap_key_aes_kw(&kek_array, &wrapped_cek)?;
-
-            // 8. Decrypt ciphertext with AES-GCM using the CEK
-            let cipher = Aes256Gcm::new_from_slice(&cek).map_err(|e| {
-                Error::Cryptography(format!("Failed to create AES-GCM cipher: {}", e))
+        // Find recipient matching our key ID or any X25519 key agreement key derived from our DID
+        let our_did = our_kid.split('#').next().unwrap_or(our_kid);
+        let recipient = jwe
+            .recipients
+            .iter()
+            .find(|r| r.header.kid == our_kid || r.header.kid.starts_with(&format!("{}#", our_did)))
+            .ok_or_else(|| {
+                Error::Cryptography(format!(
+                    "No matching recipient found for key ID: {}",
+                    our_kid
+                ))
             })?;
 
-            let nonce = Nonce::from_slice(&iv);
+        // Decode and parse the protected header to get the EPK
+        let protected_bytes =
+            crate::message::base64_decode_flexible(&jwe.protected).map_err(|e| {
+                Error::Cryptography(format!("Failed to decode protected header: {}", e))
+            })?;
 
-            let mut padded_tag = [0u8; 16];
-            let copy_len = std::cmp::min(tag.len(), 16);
-            padded_tag[..copy_len].copy_from_slice(&tag[..copy_len]);
-            let tag_array = aes_gcm::Tag::from_slice(&padded_tag);
+        let protected: JweProtected = serde_json::from_slice(&protected_bytes)
+            .map_err(|e| Error::Cryptography(format!("Failed to parse protected header: {}", e)))?;
 
-            let mut buffer = ciphertext.to_vec();
-            cipher
-                .decrypt_in_place_detached(nonce, b"", &mut buffer, tag_array)
-                .map_err(|e| Error::Cryptography(format!("AES-GCM decryption failed: {:?}", e)))?;
+        // Decode the JWE elements (accept both base64 and base64url)
+        let ciphertext = crate::message::base64_decode_flexible(&jwe.ciphertext)
+            .map_err(|e| Error::Cryptography(format!("Failed to decode ciphertext: {}", e)))?;
 
-            Ok(buffer)
-        }
+        let wrapped_cek = crate::message::base64_decode_flexible(&recipient.encrypted_key)
+            .map_err(|e| Error::Cryptography(format!("Failed to decode encrypted key: {}", e)))?;
 
-        #[cfg(not(feature = "crypto-p256"))]
-        {
-            let _ = jwe;
-            Err(Error::Cryptography(
-                "P-256 decryption not available - enable crypto-p256 feature".to_string(),
-            ))
-        }
+        let iv = crate::message::base64_decode_flexible(&jwe.iv)
+            .map_err(|e| Error::Cryptography(format!("Failed to decode IV: {}", e)))?;
+
+        let tag = crate::message::base64_decode_flexible(&jwe.tag)
+            .map_err(|e| Error::Cryptography(format!("Failed to decode tag: {}", e)))?;
+
+        // Perform ECDH based on EPK type
+        let shared_bytes: Vec<u8> = match &protected.epk {
+            #[cfg(feature = "crypto-ed25519")]
+            EphemeralPublicKey::Okp { crv, x } if crv == "X25519" => {
+                // X25519 ECDH: convert our Ed25519 private key to X25519 and perform DH
+                let epk_bytes = crate::message::base64_decode_flexible(x).map_err(|e| {
+                    Error::Cryptography(format!("Failed to decode X25519 EPK: {}", e))
+                })?;
+                if epk_bytes.len() != 32 {
+                    return Err(Error::Cryptography("Invalid X25519 EPK length".to_string()));
+                }
+
+                // Get our Ed25519 private key and convert to X25519
+                let jwk = self.private_key_jwk()?;
+                let d_b64 = jwk.get("d").and_then(|v| v.as_str()).ok_or_else(|| {
+                    Error::Cryptography("Missing private key (d) in JWK".to_string())
+                })?;
+                let d_bytes = crate::message::base64_decode_flexible(d_b64).map_err(|e| {
+                    Error::Cryptography(format!("Failed to decode private key: {}", e))
+                })?;
+
+                // Ed25519 seed → X25519 secret: SHA-512 hash of seed, first 32 bytes
+                // x25519-dalek handles clamping internally
+                use sha2::Digest;
+                let hash = sha2::Sha512::digest(&d_bytes);
+                let mut x25519_key_bytes = [0u8; 32];
+                x25519_key_bytes.copy_from_slice(&hash[..32]);
+
+                let secret = x25519_dalek::StaticSecret::from(x25519_key_bytes);
+                let epk_array: [u8; 32] = epk_bytes[..32].try_into().unwrap();
+                let public = x25519_dalek::PublicKey::from(epk_array);
+                let shared = secret.diffie_hellman(&public);
+                shared.as_bytes().to_vec()
+            }
+            #[cfg(feature = "crypto-p256")]
+            EphemeralPublicKey::Ec { x, y, .. } => {
+                // P-256 ECDH
+                let epk_x = crate::message::base64_decode_flexible(x)
+                    .map_err(|e| Error::Cryptography(format!("Failed to decode EPK x: {}", e)))?;
+                let epk_y = crate::message::base64_decode_flexible(y)
+                    .map_err(|e| Error::Cryptography(format!("Failed to decode EPK y: {}", e)))?;
+
+                let mut epk_point_bytes = vec![0x04];
+                epk_point_bytes.extend_from_slice(&epk_x);
+                epk_point_bytes.extend_from_slice(&epk_y);
+
+                let epk_encoded_point = P256EncodedPoint::from_bytes(&epk_point_bytes)
+                    .map_err(|e| Error::Cryptography(format!("Invalid EPK point: {}", e)))?;
+
+                let epk_public_key = P256PublicKey::from_encoded_point(&epk_encoded_point);
+                if epk_public_key.is_none().into() {
+                    return Err(Error::Cryptography("Invalid EPK public key".to_string()));
+                }
+                let epk_public_key = epk_public_key.unwrap();
+
+                let jwk = self.private_key_jwk()?;
+                let d_b64 = jwk.get("d").and_then(|v| v.as_str()).ok_or_else(|| {
+                    Error::Cryptography("Missing private key (d) in JWK".to_string())
+                })?;
+                let d_bytes = base64::engine::general_purpose::STANDARD
+                    .decode(d_b64)
+                    .map_err(|e| {
+                        Error::Cryptography(format!("Failed to decode private key: {}", e))
+                    })?;
+
+                let secret_key = p256::SecretKey::from_bytes((&d_bytes[..]).into())
+                    .map_err(|e| Error::Cryptography(format!("Invalid private key: {}", e)))?;
+
+                let shared_secret = p256::ecdh::diffie_hellman(
+                    secret_key.to_nonzero_scalar(),
+                    epk_public_key.as_affine(),
+                );
+                shared_secret.raw_secret_bytes().to_vec()
+            }
+            _ => {
+                return Err(Error::Cryptography(
+                    "Unsupported EPK type for JWE decryption".to_string(),
+                ))
+            }
+        };
+
+        // Derive KEK using Concat KDF
+        // Per RFC 7518 Section 4.6.2, apu and apv are base64url-decoded before use
+        let apu = if protected.apu.is_empty() {
+            Vec::new()
+        } else {
+            crate::message::base64_decode_flexible(&protected.apu).unwrap_or_default()
+        };
+        let apv = if protected.apv.is_empty() {
+            Vec::new()
+        } else {
+            crate::message::base64_decode_flexible(&protected.apv).unwrap_or_default()
+        };
+
+        let kek = crate::crypto::derive_key_ecdh_es(&shared_bytes, &apu, &apv, 256)?;
+
+        // Unwrap CEK using AES-KW
+        let mut kek_array = [0u8; 32];
+        kek_array.copy_from_slice(&kek);
+        let cek = crate::crypto::unwrap_key_aes_kw(&kek_array, &wrapped_cek)?;
+
+        // Decrypt ciphertext with AES-GCM using the CEK
+        let cipher = Aes256Gcm::new_from_slice(&cek)
+            .map_err(|e| Error::Cryptography(format!("Failed to create AES-GCM cipher: {}", e)))?;
+
+        let nonce = Nonce::from_slice(&iv);
+
+        let mut padded_tag = [0u8; 16];
+        let copy_len = std::cmp::min(tag.len(), 16);
+        padded_tag[..copy_len].copy_from_slice(&tag[..copy_len]);
+        let tag_array = aes_gcm::Tag::from_slice(&padded_tag);
+
+        let mut buffer = ciphertext.to_vec();
+        cipher
+            .decrypt_in_place_detached(nonce, jwe.protected.as_bytes(), &mut buffer, tag_array)
+            .or_else(|_| {
+                // Retry with empty AAD for backwards compatibility
+                buffer = ciphertext.to_vec();
+                cipher.decrypt_in_place_detached(nonce, b"", &mut buffer, tag_array)
+            })
+            .map_err(|e| Error::Cryptography(format!("AES-GCM decryption failed: {:?}", e)))?;
+
+        Ok(buffer)
     }
 }
 

--- a/tap-agent/src/local_agent_key.rs
+++ b/tap-agent/src/local_agent_key.rs
@@ -72,9 +72,8 @@ impl LocalAgentKey {
             Error::Cryptography(format!("Failed to decode protected header: {}", e))
         })?;
 
-        // Decode the signature from base64
-        let signature_bytes = base64::engine::general_purpose::STANDARD
-            .decode(&signature.signature)
+        // Decode the signature (accept both base64 and base64url)
+        let signature_bytes = crate::message::base64_decode_flexible(&signature.signature)
             .map_err(|e| Error::Cryptography(format!("Failed to decode signature: {}", e)))?;
 
         // Construct the signing input: {protected}.{payload}
@@ -91,9 +90,8 @@ impl LocalAgentKey {
             ));
         }
 
-        // Decode and return the payload
-        let payload_bytes = base64::engine::general_purpose::STANDARD
-            .decode(&jws.payload)
+        // Decode and return the payload (accept both base64 and base64url)
+        let payload_bytes = crate::message::base64_decode_flexible(&jws.payload)
             .map_err(|e| Error::Cryptography(format!("Failed to decode payload: {}", e)))?;
 
         Ok(payload_bytes)
@@ -658,8 +656,8 @@ impl SigningKey for LocalAgentKey {
         payload: &[u8],
         protected_header: Option<JwsProtected>,
     ) -> Result<Jws> {
-        // Base64 encode the payload
-        let payload_b64 = base64::engine::general_purpose::STANDARD.encode(payload);
+        // Base64URL encode the payload (no padding) per RFC 7515
+        let payload_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload);
 
         // Create the protected header if not provided, respecting the key type
         let protected = if let Some(mut header) = protected_header {
@@ -683,7 +681,7 @@ impl SigningKey for LocalAgentKey {
             Error::Serialization(format!("Failed to serialize protected header: {}", e))
         })?;
 
-        let protected_b64 = base64::engine::general_purpose::STANDARD.encode(protected_json);
+        let protected_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(protected_json);
 
         // Create the signing input (protected.payload)
         let signing_input = format!("{}.{}", protected_b64, payload_b64);
@@ -691,8 +689,8 @@ impl SigningKey for LocalAgentKey {
         // Sign the input
         let signature = self.sign(signing_input.as_bytes()).await?;
 
-        // Encode the signature to base64
-        let signature_value = base64::engine::general_purpose::STANDARD.encode(&signature);
+        // Base64URL encode the signature (no padding) per RFC 7515
+        let signature_value = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&signature);
 
         // Create the JWS with signature
         let jws = Jws {
@@ -1335,9 +1333,8 @@ impl PublicVerificationKey {
             Error::Cryptography(format!("Failed to decode protected header: {}", e))
         })?;
 
-        // Decode the signature
-        let signature_bytes = base64::engine::general_purpose::STANDARD
-            .decode(&signature.signature)
+        // Decode the signature (accept both base64 and base64url)
+        let signature_bytes = crate::message::base64_decode_flexible(&signature.signature)
             .map_err(|e| Error::Cryptography(format!("Failed to decode signature: {}", e)))?;
 
         // Create the signing input (protected.payload)
@@ -1355,9 +1352,8 @@ impl PublicVerificationKey {
             ));
         }
 
-        // Decode the payload
-        let payload_bytes = base64::engine::general_purpose::STANDARD
-            .decode(&jws.payload)
+        // Decode the payload (accept both base64 and base64url)
+        let payload_bytes = crate::message::base64_decode_flexible(&jws.payload)
             .map_err(|e| Error::Cryptography(format!("Failed to decode payload: {}", e)))?;
 
         Ok(payload_bytes)

--- a/tap-agent/src/message.rs
+++ b/tap-agent/src/message.rs
@@ -211,7 +211,10 @@ pub struct JweHeader {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct JweProtected {
     pub epk: EphemeralPublicKey,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub apv: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub apu: String,
     #[serde(default = "default_didcomm_encrypted")]
     pub typ: String,
     pub enc: String,

--- a/tap-agent/src/message.rs
+++ b/tap-agent/src/message.rs
@@ -4,8 +4,18 @@
 //! including security modes and message type identifiers.
 
 use base64::{engine::general_purpose, Engine};
-use serde::{Deserialize, Serialize};
-// Value is not used in this file
+use serde::de::{self, MapAccess, Visitor};
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Decode a base64-encoded string, accepting both standard base64 and base64url (with or without padding).
+pub fn base64_decode_flexible(input: &str) -> Result<Vec<u8>, base64::DecodeError> {
+    general_purpose::URL_SAFE_NO_PAD
+        .decode(input)
+        .or_else(|_| general_purpose::URL_SAFE.decode(input))
+        .or_else(|_| general_purpose::STANDARD.decode(input))
+        .or_else(|_| general_purpose::STANDARD_NO_PAD.decode(input))
+}
 
 /// Security mode for message packing and unpacking.
 ///
@@ -40,10 +50,99 @@ pub const DIDCOMM_ENCRYPTED: &str = "application/didcomm-encrypted+json";
 
 // JWS-related types
 
-#[derive(Serialize, Deserialize, Debug)]
+/// JWS (JSON Web Signature) supporting both General and Flattened serializations per RFC 7515.
+///
+/// When serializing:
+/// - Single signature: uses Flattened JWS format (`protected`, `payload`, `signature` at top level)
+/// - Multiple signatures: uses General JWS format (`payload`, `signatures` array)
+///
+/// When deserializing: accepts both formats.
+#[derive(Debug)]
 pub struct Jws {
     pub payload: String,
     pub signatures: Vec<JwsSignature>,
+}
+
+impl Serialize for Jws {
+    fn serialize<S: Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        if self.signatures.len() == 1 {
+            // Flattened JWS: { "protected", "payload", "signature" }
+            let sig = &self.signatures[0];
+            let mut map = serializer.serialize_map(Some(3))?;
+            map.serialize_entry("payload", &self.payload)?;
+            map.serialize_entry("protected", &sig.protected)?;
+            map.serialize_entry("signature", &sig.signature)?;
+            map.end()
+        } else {
+            // General JWS: { "payload", "signatures": [...] }
+            let mut map = serializer.serialize_map(Some(2))?;
+            map.serialize_entry("payload", &self.payload)?;
+            map.serialize_entry("signatures", &self.signatures)?;
+            map.end()
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Jws {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        struct JwsVisitor;
+
+        impl<'de> Visitor<'de> for JwsVisitor {
+            type Value = Jws;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a JWS in General or Flattened serialization")
+            }
+
+            fn visit_map<M: MapAccess<'de>>(
+                self,
+                mut map: M,
+            ) -> std::result::Result<Jws, M::Error> {
+                let mut payload: Option<String> = None;
+                let mut signatures: Option<Vec<JwsSignature>> = None;
+                // Flattened fields
+                let mut protected: Option<String> = None;
+                let mut signature: Option<String> = None;
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "payload" => payload = Some(map.next_value()?),
+                        "signatures" => signatures = Some(map.next_value()?),
+                        "protected" => protected = Some(map.next_value()?),
+                        "signature" => signature = Some(map.next_value()?),
+                        _ => {
+                            let _: serde_json::Value = map.next_value()?;
+                        }
+                    }
+                }
+
+                let payload = payload.ok_or_else(|| de::Error::missing_field("payload"))?;
+
+                // Prefer General format if "signatures" is present
+                if let Some(sigs) = signatures {
+                    Ok(Jws {
+                        payload,
+                        signatures: sigs,
+                    })
+                } else if let (Some(prot), Some(sig)) = (protected, signature) {
+                    // Flattened format
+                    Ok(Jws {
+                        payload,
+                        signatures: vec![JwsSignature {
+                            protected: prot,
+                            signature: sig,
+                        }],
+                    })
+                } else {
+                    Err(de::Error::custom(
+                        "JWS must have either 'signatures' array or 'protected'+'signature' fields",
+                    ))
+                }
+            }
+        }
+
+        deserializer.deserialize_map(JwsVisitor)
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -69,8 +168,7 @@ fn default_didcomm_signed() -> String {
 impl JwsSignature {
     /// Extracts the kid (key identifier) from the protected header
     pub fn get_kid(&self) -> Option<String> {
-        // Decode the protected header and extract kid
-        if let Ok(protected_bytes) = general_purpose::STANDARD.decode(&self.protected) {
+        if let Ok(protected_bytes) = base64_decode_flexible(&self.protected) {
             if let Ok(protected) = serde_json::from_slice::<JwsProtected>(&protected_bytes) {
                 return Some(protected.kid);
             }
@@ -80,7 +178,7 @@ impl JwsSignature {
 
     /// Decodes and returns the protected header
     pub fn get_protected_header(&self) -> Result<JwsProtected, Box<dyn std::error::Error>> {
-        let protected_bytes = general_purpose::STANDARD.decode(&self.protected)?;
+        let protected_bytes = base64_decode_flexible(&self.protected)?;
         let protected = serde_json::from_slice::<JwsProtected>(&protected_bytes)?;
         Ok(protected)
     }

--- a/tap-agent/src/message_packing.rs
+++ b/tap-agent/src/message_packing.rs
@@ -8,7 +8,6 @@ use crate::agent_key::VerificationKey;
 use crate::error::{Error, Result};
 use crate::message::{Jwe, Jws, SecurityMode};
 use async_trait::async_trait;
-use base64::Engine;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::Value;
@@ -646,9 +645,8 @@ impl<T: DeserializeOwned + Send + 'static> Unpackable<Jws, T> for Jws {
         key_manager: &(impl KeyManagerPacking + ?Sized),
         _options: UnpackOptions,
     ) -> Result<T> {
-        // Decode the payload
-        let payload_bytes = base64::engine::general_purpose::STANDARD
-            .decode(&packed_message.payload)
+        // Decode the payload (accept both base64 and base64url)
+        let payload_bytes = crate::message::base64_decode_flexible(&packed_message.payload)
             .map_err(|e| Error::Cryptography(format!("Failed to decode JWS payload: {}", e)))?;
 
         // Convert to string
@@ -663,9 +661,8 @@ impl<T: DeserializeOwned + Send + 'static> Unpackable<Jws, T> for Jws {
         let mut verified = false;
 
         for signature in &packed_message.signatures {
-            // Decode the protected header
-            let protected_bytes = base64::engine::general_purpose::STANDARD
-                .decode(&signature.protected)
+            // Decode the protected header (accept both base64 and base64url)
+            let protected_bytes = crate::message::base64_decode_flexible(&signature.protected)
                 .map_err(|e| {
                     Error::Cryptography(format!("Failed to decode protected header: {}", e))
                 })?;
@@ -688,9 +685,8 @@ impl<T: DeserializeOwned + Send + 'static> Unpackable<Jws, T> for Jws {
                 Err(_) => continue, // Skip key if we can't resolve it
             };
 
-            // Decode the signature
-            let signature_bytes = base64::engine::general_purpose::STANDARD
-                .decode(&signature.signature)
+            // Decode the signature (accept both base64 and base64url)
+            let signature_bytes = crate::message::base64_decode_flexible(&signature.signature)
                 .map_err(|e| Error::Cryptography(format!("Failed to decode signature: {}", e)))?;
 
             // Create the signing input (protected.payload)
@@ -806,9 +802,13 @@ impl<T: DeserializeOwned + Send + 'static> Unpackable<String, T> for String {
     ) -> Result<T> {
         // Try to parse as JSON first
         if let Ok(value) = serde_json::from_str::<Value>(packed_message) {
-            // Check if it's a JWS (has payload and signatures fields)
-            if value.get("payload").is_some() && value.get("signatures").is_some() {
-                // Parse as JWS
+            // Check if it's a JWS (General or Flattened serialization)
+            // General: has "payload" + "signatures" array
+            // Flattened: has "payload" + "signature" + "protected"
+            if value.get("payload").is_some()
+                && (value.get("signatures").is_some() || value.get("signature").is_some())
+            {
+                // Jws custom Deserialize handles both General and Flattened formats
                 let jws: Jws = serde_json::from_str(packed_message)
                     .map_err(|e| Error::Serialization(e.to_string()))?;
 
@@ -1090,7 +1090,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_unpack_with_wrong_signature() {
-        // Create two different key managers
+        // Create a key manager and sign a message
         let key_manager1 = Arc::new(AgentKeyManagerBuilder::new().build().unwrap());
         let key1 = key_manager1
             .generate_key(DIDGenerationOptions {
@@ -1098,14 +1098,6 @@ mod tests {
             })
             .unwrap();
 
-        let key_manager2 = Arc::new(AgentKeyManagerBuilder::new().build().unwrap());
-        let _key2 = key_manager2
-            .generate_key(DIDGenerationOptions {
-                key_type: KeyType::Ed25519,
-            })
-            .unwrap();
-
-        // Create and sign a message with key1
         let message = PlainMessage {
             id: "test-wrong-sig".to_string(),
             typ: "application/didcomm-plain+json".to_string(),
@@ -1124,17 +1116,74 @@ mod tests {
             extra_headers: Default::default(),
         };
 
-        // Get the actual verification method ID from the DID document
         let sender_kid = key1.did_doc.verification_method[0].id.clone();
         let pack_options = PackOptions::new().with_sign(&sender_kid);
         let packed = message.pack(&*key_manager1, pack_options).await.unwrap();
 
-        // Try to unpack with key_manager2 (should fail)
+        // Tamper with the signature to make it invalid
+        let mut jws: crate::message::Jws = serde_json::from_str(&packed).unwrap();
+        // Corrupt the signature bytes
+        jws.signatures[0].signature = "AAAA_invalid_signature_AAAA".to_string();
+        let tampered = serde_json::to_string(&jws).unwrap();
+
+        // Try to unpack tampered message (should fail verification)
         let unpack_options = UnpackOptions::new();
         let result: Result<PlainMessage> =
-            String::unpack(&packed, &*key_manager2, unpack_options).await;
+            String::unpack(&tampered, &*key_manager1, unpack_options).await;
 
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_unpack_cross_agent_with_did_key() {
+        // Verify that did:key resolution allows cross-agent verification
+        let key_manager1 = Arc::new(AgentKeyManagerBuilder::new().build().unwrap());
+        let key1 = key_manager1
+            .generate_key(DIDGenerationOptions {
+                key_type: KeyType::Ed25519,
+            })
+            .unwrap();
+
+        let key_manager2 = Arc::new(AgentKeyManagerBuilder::new().build().unwrap());
+        let _key2 = key_manager2
+            .generate_key(DIDGenerationOptions {
+                key_type: KeyType::Ed25519,
+            })
+            .unwrap();
+
+        let message = PlainMessage {
+            id: "test-cross-agent".to_string(),
+            typ: "application/didcomm-plain+json".to_string(),
+            type_: "https://example.org/test".to_string(),
+            body: serde_json::json!({
+                "content": "Cross-agent verification"
+            }),
+            from: key1.did.clone(),
+            to: vec!["did:example:bob".to_string()],
+            thid: None,
+            pthid: None,
+            created_time: Some(1234567890),
+            expires_time: None,
+            from_prior: None,
+            attachments: None,
+            extra_headers: Default::default(),
+        };
+
+        let sender_kid = key1.did_doc.verification_method[0].id.clone();
+        let pack_options = PackOptions::new().with_sign(&sender_kid);
+        let packed = message.pack(&*key_manager1, pack_options).await.unwrap();
+
+        // key_manager2 can verify because did:key embeds the public key
+        let unpack_options = UnpackOptions::new();
+        let result: PlainMessage = String::unpack(&packed, &*key_manager2, unpack_options)
+            .await
+            .unwrap();
+
+        assert_eq!(result.id, "test-cross-agent");
+        assert_eq!(
+            result.body,
+            serde_json::json!({"content": "Cross-agent verification"})
+        );
     }
 
     #[tokio::test]

--- a/tap-agent/src/message_packing.rs
+++ b/tap-agent/src/message_packing.rs
@@ -745,6 +745,7 @@ impl<T: DeserializeOwned + Send + 'static> Unpackable<Jwe, T> for Jwe {
         };
 
         // Try each recipient until we find one we can decrypt
+        let mut last_error = None;
         for recipient in recipients {
             // Get the recipient's key ID
             let kid = &recipient.header.kid;
@@ -752,7 +753,10 @@ impl<T: DeserializeOwned + Send + 'static> Unpackable<Jwe, T> for Jwe {
             // Get the decryption key
             let decryption_key = match key_manager.get_decryption_key(kid).await {
                 Ok(key) => key,
-                Err(_) => continue, // Skip if we don't have the key
+                Err(e) => {
+                    last_error = Some(format!("Key lookup failed for {}: {}", kid, e));
+                    continue;
+                }
             };
 
             // Try to decrypt
@@ -783,12 +787,19 @@ impl<T: DeserializeOwned + Send + 'static> Unpackable<Jwe, T> for Jwe {
                     return serde_json::from_value(plain_message.body)
                         .map_err(|e| Error::Serialization(e.to_string()));
                 }
-                Err(_) => continue, // Try next recipient
+                Err(e) => {
+                    last_error = Some(format!("Decryption failed for {}: {}", kid, e));
+                    continue;
+                }
             }
         }
 
         // If we get here, we couldn't decrypt for any recipient
-        Err(Error::Cryptography("Failed to decrypt message".to_string()))
+        Err(Error::Cryptography(format!(
+            "Failed to decrypt JWE for any of {} recipients{}",
+            packed_message.recipients.len(),
+            last_error.map(|e| format!(": {}", e)).unwrap_or_default()
+        )))
     }
 }
 

--- a/tap-agent/src/verification.rs
+++ b/tap-agent/src/verification.rs
@@ -2,7 +2,6 @@
 use crate::did::SyncDIDResolver;
 use crate::error::{Error, Result};
 use crate::message::{Jws, JwsProtected};
-use base64::Engine;
 use tap_msg::didcomm::PlainMessage;
 
 /// Verify a JWS (JSON Web Signature) message using DID resolution
@@ -76,18 +75,17 @@ pub async fn verify_jws(jws: &Jws, resolver: &dyn SyncDIDResolver) -> Result<Pla
             }
         };
 
-        // Decode the protected header
-        let protected_bytes =
-            match base64::engine::general_purpose::STANDARD.decode(&signature.protected) {
-                Ok(bytes) => bytes,
-                Err(e) => {
-                    last_error = Some(Error::Cryptography(format!(
-                        "Failed to decode protected header: {}",
-                        e
-                    )));
-                    continue;
-                }
-            };
+        // Decode the protected header (accept both base64 and base64url)
+        let protected_bytes = match crate::message::base64_decode_flexible(&signature.protected) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                last_error = Some(Error::Cryptography(format!(
+                    "Failed to decode protected header: {}",
+                    e
+                )));
+                continue;
+            }
+        };
 
         // Parse the protected header
         let protected: JwsProtected = match serde_json::from_slice(&protected_bytes) {
@@ -104,18 +102,17 @@ pub async fn verify_jws(jws: &Jws, resolver: &dyn SyncDIDResolver) -> Result<Pla
         // Create the signing input (protected.payload)
         let signing_input = format!("{}.{}", signature.protected, jws.payload);
 
-        // Decode the signature
-        let signature_bytes =
-            match base64::engine::general_purpose::STANDARD.decode(&signature.signature) {
-                Ok(bytes) => bytes,
-                Err(e) => {
-                    last_error = Some(Error::Cryptography(format!(
-                        "Failed to decode signature: {}",
-                        e
-                    )));
-                    continue;
-                }
-            };
+        // Decode the signature (accept both base64 and base64url)
+        let signature_bytes = match crate::message::base64_decode_flexible(&signature.signature) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                last_error = Some(Error::Cryptography(format!(
+                    "Failed to decode signature: {}",
+                    e
+                )));
+                continue;
+            }
+        };
 
         // Verify the signature based on the algorithm
         let verified = match protected.alg.as_str() {
@@ -130,8 +127,7 @@ pub async fn verify_jws(jws: &Jws, resolver: &dyn SyncDIDResolver) -> Result<Pla
 
         if verified {
             // Decode and return the payload
-            let payload_bytes = base64::engine::general_purpose::STANDARD
-                .decode(&jws.payload)
+            let payload_bytes = crate::message::base64_decode_flexible(&jws.payload)
                 .map_err(|e| Error::Cryptography(format!("Failed to decode payload: {}", e)))?;
 
             let payload_str = String::from_utf8(payload_bytes)

--- a/tap-agent/tests/security_integration_tests.rs
+++ b/tap-agent/tests/security_integration_tests.rs
@@ -182,14 +182,15 @@ async fn test_tampered_signature_fails() {
 
     let mut jws = key.create_jws(message, None).await.unwrap();
 
-    // Tamper with signature
-    let mut sig_bytes = base64::engine::general_purpose::STANDARD
+    // Tamper with signature (use URL_SAFE_NO_PAD since JWS now uses base64url)
+    let mut sig_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
         .decode(&jws.signatures[0].signature)
         .unwrap();
     if !sig_bytes.is_empty() {
         sig_bytes[0] ^= 0xFF;
     }
-    jws.signatures[0].signature = base64::engine::general_purpose::STANDARD.encode(&sig_bytes);
+    jws.signatures[0].signature =
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&sig_bytes);
 
     // Verification should fail
     let result = key.verify_jws(&jws).await;

--- a/tap-http/src/bin/mock-server.rs
+++ b/tap-http/src/bin/mock-server.rs
@@ -41,7 +41,7 @@ async fn handle_request(
             // Try to parse as JSON to verify structure
             if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body_str) {
                 // Check if the message has signature information
-                if let Some(signatures) = json.get("signatures") {
+                if let Some(signatures) = json.get("signatures").or_else(|| json.get("signature")) {
                     println!("\nSignature information detected:");
                     println!("{}", serde_json::to_string_pretty(signatures).unwrap());
                 }

--- a/tap-node/src/lib.rs
+++ b/tap-node/src/lib.rs
@@ -463,7 +463,8 @@ impl TapNode {
         // Determine message type
         let is_encrypted =
             message.get("protected").is_some() && message.get("recipients").is_some();
-        let is_signed = message.get("payload").is_some() && message.get("signatures").is_some();
+        let is_signed = message.get("payload").is_some()
+            && (message.get("signatures").is_some() || message.get("signature").is_some());
 
         // Helper function to store received message in agent storage
         #[cfg(feature = "storage")]

--- a/tap-ts/tests/integration.test.ts
+++ b/tap-ts/tests/integration.test.ts
@@ -72,11 +72,11 @@ describe('Integration Tests', () => {
       expect(packed).toHaveProperty('message');
       expect(packed).toHaveProperty('metadata');
       
-      // Parse the JWS message
+      // Parse the Flattened JWS message
       const jws = JSON.parse(packed.message);
       expect(jws).toHaveProperty('payload');
-      expect(jws).toHaveProperty('signatures');
-      expect(Array.isArray(jws.signatures)).toBe(true);
+      expect(jws).toHaveProperty('protected');
+      expect(jws).toHaveProperty('signature');
       expect(jws.payload).toMatch(/^eyJ/);
 
       // For this test, let's use the same agent to unpack (self-signed)
@@ -134,7 +134,7 @@ describe('Integration Tests', () => {
       
       const jws = JSON.parse(packedTransfer.message);
       expect(jws).toHaveProperty('payload');
-      expect(jws).toHaveProperty('signatures');
+      expect(jws).toHaveProperty('signature');
 
       // Step 3: Originator unpacks (self-signed for this test)
       // In real scenarios, proper key exchange would be needed
@@ -185,7 +185,7 @@ describe('Integration Tests', () => {
       
       const jws = JSON.parse(packed.message);
       expect(jws).toHaveProperty('payload');
-      expect(jws).toHaveProperty('signatures');
+      expect(jws).toHaveProperty('signature');
       
       // Unpack to verify the core message was preserved
       const unpacked = await agent.unpack(packed.message);
@@ -237,7 +237,7 @@ describe('Integration Tests', () => {
       
       const jws = JSON.parse(packed.message);
       expect(jws).toHaveProperty('payload');
-      expect(jws).toHaveProperty('signatures');
+      expect(jws).toHaveProperty('signature');
       
       // Verify unpacking works with large payloads
       const unpacked = await agent.unpack(packed.message);
@@ -304,7 +304,7 @@ describe('Integration Tests', () => {
         
         const jws = JSON.parse(packed.message);
         expect(jws).toHaveProperty('payload');
-        expect(jws).toHaveProperty('signatures');
+        expect(jws).toHaveProperty('signature');
       });
       
       // Verify we can unpack all messages and they contain correct content
@@ -360,7 +360,7 @@ describe('Integration Tests', () => {
       
       const jws = JSON.parse(packed.message);
       expect(jws).toHaveProperty('payload');
-      expect(jws).toHaveProperty('signatures');
+      expect(jws).toHaveProperty('signature');
 
       // Verify the typed body survives the WASM round-trip
       const unpacked = await agent.unpack(packed.message);
@@ -413,7 +413,7 @@ describe('Integration Tests', () => {
         
         const jws = JSON.parse(packed.message);
         expect(jws).toHaveProperty('payload');
-        expect(jws).toHaveProperty('signatures');
+        expect(jws).toHaveProperty('signature');
       });
 
       // Should complete operations in reasonable time (< 5 seconds for real WASM)

--- a/tap-ts/tests/interoperability-real.test.ts
+++ b/tap-ts/tests/interoperability-real.test.ts
@@ -44,18 +44,14 @@ describe('Real WASM Interoperability Tests', () => {
 
       const packed = await aliceAgent.pack(message);
       
-      // Verify it's a valid JWS structure (now returns object directly)
-      // Parse the JWS from the packed message result
+      // Verify it's a valid Flattened JWS structure
       const jws = JSON.parse(packed.message);
       expect(jws).toHaveProperty('payload');
-      expect(jws).toHaveProperty('signatures');
-      
+      expect(jws).toHaveProperty('protected');
+      expect(jws).toHaveProperty('signature');
+
       // Payload should be base64url encoded
       expect(jws.payload).toMatch(/^[A-Za-z0-9_-]+$/);
-      
-      // Should have at least one signature
-      expect(jws.signatures).toBeInstanceOf(Array);
-      expect(jws.signatures.length).toBeGreaterThan(0);
     });
 
     it('should handle standard DIDComm message types', async () => {
@@ -87,7 +83,7 @@ describe('Real WASM Interoperability Tests', () => {
         
         const jws = JSON.parse(packed.message);
         expect(jws).toHaveProperty('payload');
-        expect(jws).toHaveProperty('signatures');
+        expect(jws).toHaveProperty('signature');
       }
     });
 
@@ -223,21 +219,19 @@ describe('Real WASM Interoperability Tests', () => {
       // Parse the JWS from the packed message result
       const jws = JSON.parse(packed.message);
       
-      // Check message format  
-      if (jws.payload && jws.signatures) {
-        // JWS format
-        expect(jws.signatures[0]).toHaveProperty('protected');
-        expect(jws.signatures[0]).toHaveProperty('signature');
-        
-        // Decode protected header
-        const protectedHeader = JSON.parse(
-          Buffer.from(jws.signatures[0].protected, 'base64url').toString()
-        );
-        
-        // Should specify algorithm
-        expect(protectedHeader).toHaveProperty('alg');
-        expect(['EdDSA', 'ES256', 'ES256K']).toContain(protectedHeader.alg);
-      }
+      // Check Flattened JWS format
+      expect(jws).toHaveProperty('payload');
+      expect(jws).toHaveProperty('protected');
+      expect(jws).toHaveProperty('signature');
+
+      // Decode protected header
+      const protectedHeader = JSON.parse(
+        Buffer.from(jws.protected, 'base64url').toString()
+      );
+
+      // Should specify algorithm
+      expect(protectedHeader).toHaveProperty('alg');
+      expect(['EdDSA', 'ES256', 'ES256K']).toContain(protectedHeader.alg);
     });
 
     it('should handle authenticated vs anonymous encryption', async () => {
@@ -257,14 +251,13 @@ describe('Real WASM Interoperability Tests', () => {
       const authJws = JSON.parse(authPacked.message);
       
       // JWS always reveals sender through signature
-      if (authJws.signatures) {
-        const protectedHeader = JSON.parse(
-          Buffer.from(authJws.signatures[0].protected, 'base64url').toString()
-        );
-        
-        // Sender's key ID should be in the protected header
-        expect(protectedHeader).toHaveProperty('kid');
-      }
+      expect(authJws).toHaveProperty('protected');
+      const protectedHeader2 = JSON.parse(
+        Buffer.from(authJws.protected, 'base64url').toString()
+      );
+
+      // Sender's key ID should be in the protected header
+      expect(protectedHeader2).toHaveProperty('kid');
     });
   });
 

--- a/tap-ts/tests/simple.test.ts
+++ b/tap-ts/tests/simple.test.ts
@@ -56,20 +56,15 @@ describe('Simple Real WASM Tests', () => {
     expect(packed).toHaveProperty('message');
     expect(packed).toHaveProperty('metadata');
     
-    // Parse and verify JWS
+    // Parse and verify Flattened JWS
     const jws = JSON.parse(packed.message);
     expect(jws).toHaveProperty('payload');
-    expect(jws).toHaveProperty('signatures');
-    expect(jws.signatures.length).toBeGreaterThan(0);
-    
-    // Verify signature structure
-    const signature = jws.signatures[0];
-    expect(signature).toHaveProperty('protected');
-    expect(signature).toHaveProperty('signature');
-    
+    expect(jws).toHaveProperty('protected');
+    expect(jws).toHaveProperty('signature');
+
     // Decode and verify protected header
     const protectedHeader = JSON.parse(
-      Buffer.from(signature.protected, 'base64url').toString()
+      Buffer.from(jws.protected, 'base64url').toString()
     );
     expect(protectedHeader).toHaveProperty('alg');
     expect(protectedHeader).toHaveProperty('kid');

--- a/tap-ts/tests/tap-agent.test.ts
+++ b/tap-ts/tests/tap-agent.test.ts
@@ -116,11 +116,11 @@ describe('TapAgent with Real WASM', () => {
         expect(packed).toHaveProperty('metadata');
         expect(packed.metadata.type).toBe('signed');
 
-        // Verify JWS structure
+        // Verify Flattened JWS structure
         const jws = JSON.parse(packed.message);
         expect(jws).toHaveProperty('payload');
-        expect(jws).toHaveProperty('signatures');
-        expect(Array.isArray(jws.signatures)).toBe(true);
+        expect(jws).toHaveProperty('protected');
+        expect(jws).toHaveProperty('signature');
       });
 
       it('should pack a Transfer message', async () => {
@@ -141,7 +141,7 @@ describe('TapAgent with Real WASM', () => {
 
         const jws = JSON.parse(packed.message);
         expect(jws.payload).toBeDefined();
-        expect(jws.signatures.length).toBeGreaterThan(0);
+        expect(jws.signature).toBeDefined();
       });
 
       it('should handle message with custom options', async () => {
@@ -402,7 +402,7 @@ describe('TapAgent with Real WASM', () => {
       const jws = JSON.parse(packed.message);
 
       expect(jws).toHaveProperty('payload');
-      expect(jws).toHaveProperty('signatures');
+      expect(jws).toHaveProperty('signature');
     });
 
     it('should type-check packed message metadata', async () => {

--- a/tap-ts/tests/veramo-format-compatibility.test.ts
+++ b/tap-ts/tests/veramo-format-compatibility.test.ts
@@ -38,22 +38,15 @@ describe('TAP-Veramo Message Format Compatibility', () => {
 
       const packed = await tapAgent.pack(message);
 
-      // Verify it matches Veramo's expected JWS structure
-      // Parse the JWS from the packed message result
+      // Verify it matches Veramo's expected Flattened JWS structure
       const jws = JSON.parse(packed.message);
       expect(jws).toHaveProperty('payload');
-      expect(jws).toHaveProperty('signatures');
-      expect(Array.isArray(jws.signatures)).toBe(true);
-      expect(jws.signatures.length).toBeGreaterThan(0);
-
-      // Check signature structure
-      const sig = jws.signatures[0];
-      expect(sig).toHaveProperty('protected');
-      expect(sig).toHaveProperty('signature');
+      expect(jws).toHaveProperty('protected');
+      expect(jws).toHaveProperty('signature');
 
       // Decode and verify protected header
       const protectedHeader = JSON.parse(
-        Buffer.from(sig.protected, 'base64url').toString()
+        Buffer.from(jws.protected, 'base64url').toString()
       );
 
       // Veramo expects these fields in JWS
@@ -134,10 +127,11 @@ describe('TAP-Veramo Message Format Compatibility', () => {
         };
 
         const packed = await tapAgent.pack(message);
-        // All should produce valid JWS
+        // All should produce valid Flattened JWS
         const jws = JSON.parse(packed.message);
         expect(jws).toHaveProperty('payload');
-        expect(jws).toHaveProperty('signatures');
+        expect(jws).toHaveProperty('protected');
+        expect(jws).toHaveProperty('signature');
       }
     });
 
@@ -158,21 +152,22 @@ describe('TAP-Veramo Message Format Compatibility', () => {
           from: tapAgent.did,
           to: ['did:key:z6MktestRecipient'],
           created_time: Date.now(),
-          body: { 
+          body: {
             '@context': 'https://tap.rsvp/schema/1.0',
             '@type': messageType.split('#')[1]
           }
         };
 
         const packed = await tapAgent.pack(message);
-        // TAP messages should also use standard JWS format
+        // TAP messages should use Flattened JWS format
         const jws = JSON.parse(packed.message);
         expect(jws).toHaveProperty('payload');
-        expect(jws).toHaveProperty('signatures');
+        expect(jws).toHaveProperty('protected');
+        expect(jws).toHaveProperty('signature');
 
         // Verify TAP messages maintain DIDComm v2 compatibility
         const protectedHeader = JSON.parse(
-          Buffer.from(jws.signatures[0].protected, 'base64url').toString()
+          Buffer.from(jws.protected, 'base64url').toString()
         );
         expect(protectedHeader.typ).toBe('application/didcomm-signed+json');
       }
@@ -237,7 +232,7 @@ describe('TAP-Veramo Message Format Compatibility', () => {
       const jws = JSON.parse(packed.message);
       
       const protectedHeader = JSON.parse(
-        Buffer.from(jws.signatures[0].protected, 'base64url').toString()
+        Buffer.from(jws.protected, 'base64url').toString()
       );
 
       // Key ID should follow DID URL format

--- a/tap-ts/tests/veramo-integration.test.ts
+++ b/tap-ts/tests/veramo-integration.test.ts
@@ -23,8 +23,8 @@ import {
   IResolver,
   TAgent,
 } from "@veramo/core";
-import { DIDManager } from "@veramo/did-manager";
-import { KeyManager } from "@veramo/key-manager";
+import { DIDManager, MemoryDIDStore } from "@veramo/did-manager";
+import { KeyManager, MemoryKeyStore, MemoryPrivateKeyStore } from "@veramo/key-manager";
 import { KeyManagementSystem } from "@veramo/kms-local";
 import { DIDResolverPlugin } from "@veramo/did-resolver";
 import { KeyDIDProvider } from "@veramo/did-provider-key";
@@ -32,50 +32,6 @@ import { MessageHandler } from "@veramo/message-handler";
 import { DIDComm, IDIDComm, DIDCommMessageHandler } from "@veramo/did-comm";
 import { Resolver } from "did-resolver";
 import { getResolver as getKeyResolver } from "key-did-resolver";
-
-// Simple in-memory key store implementation
-class MemoryKeyStore {
-  private keys: Map<string, any> = new Map();
-
-  async importKey(key: any) {
-    this.keys.set(key.kid, key);
-    return true;
-  }
-
-  async getKey(kid: string) {
-    return this.keys.get(kid);
-  }
-
-  async deleteKey(kid: string) {
-    return this.keys.delete(kid);
-  }
-
-  async listKeys() {
-    return Array.from(this.keys.values());
-  }
-}
-
-// Simple in-memory DID store implementation
-class MemoryDIDStore {
-  private dids: Map<string, any> = new Map();
-
-  async importDID(did: any) {
-    this.dids.set(did.did, did);
-    return true;
-  }
-
-  async getDID(didUrl: string) {
-    return this.dids.get(didUrl);
-  }
-
-  async deleteDID(did: string) {
-    return this.dids.delete(did);
-  }
-
-  async listDIDs() {
-    return Array.from(this.dids.values());
-  }
-}
 
 // Get the path to the WASM binary
 const __filename = fileURLToPath(import.meta.url);
@@ -86,19 +42,11 @@ type IAgent = TAgent<IDIDManager & IKeyManager & IMessageHandler & IResolver & I
 
 /**
  * TAP-Veramo Interoperability Tests
- * 
- * NOTE: Full bidirectional message exchange between TAP and Veramo requires:
- * 1. Veramo to resolve TAP DIDs (needs a TAP DID resolver plugin)
- * 2. TAP to resolve Veramo DIDs (already works via did:key)
- * 3. Both to support the same packing formats (JWS works, JWE needs setup)
- * 
- * Current Status:
- * - TAP produces Veramo-compatible JWS messages ✅
- * - TAP can process Veramo DID formats ✅
- * - Message format compatibility verified ✅
- * - Full integration requires DID resolver setup for Veramo
- * 
- * See veramo-format-compatibility.test.ts for detailed format tests
+ *
+ * Tests bidirectional DIDComm v2 message exchange between TAP and Veramo agents.
+ * Both use did:key identifiers and JWS (signed) message packing.
+ *
+ * See veramo-format-compatibility.test.ts for detailed format tests.
  */
 describe("TAP-Veramo Interoperability Tests", () => {
   let tapAgent: TapAgent;
@@ -118,12 +66,12 @@ describe("TAP-Veramo Interoperability Tests", () => {
     // Create TAP agent
     tapAgent = await TapAgent.create({ keyType: "Ed25519" });
 
-    // Create Veramo agents with DIDComm support
+    // Create Veramo agents with DIDComm support using built-in memory stores
     const createVeramoAgent = () =>
       createAgent<IDIDManager & IKeyManager & IMessageHandler & IResolver & IDIDComm>({
         plugins: [
           new DIDManager({
-            store: new MemoryDIDStore() as any,
+            store: new MemoryDIDStore(),
             defaultProvider: "did:key",
             providers: {
               "did:key": new KeyDIDProvider({
@@ -132,9 +80,9 @@ describe("TAP-Veramo Interoperability Tests", () => {
             },
           }),
           new KeyManager({
-            store: new MemoryKeyStore() as any,
+            store: new MemoryKeyStore(),
             kms: {
-              local: new KeyManagementSystem(new MemoryKeyStore() as any),
+              local: new KeyManagementSystem(new MemoryPrivateKeyStore()),
             },
           }),
           new DIDResolverPlugin({
@@ -219,15 +167,12 @@ describe("TAP-Veramo Interoperability Tests", () => {
 
   describe("Message Format Compatibility", () => {
     it("should unpack messages packed by Veramo (JWS)", async () => {
-      // Create Veramo sender with the agent that will pack the message
       const veramoSender = await veramoAgent.didManagerCreate({
         provider: "did:key",
         kms: "local",
         options: { keyType: "Ed25519" },
       });
 
-      // Create a message and pack it with Veramo using JWS
-      // The from field must be managed by this agent
       const message = {
         id: "veramo-jws-001",
         type: "https://didcomm.org/basicmessage/2.0/message",
@@ -238,34 +183,25 @@ describe("TAP-Veramo Interoperability Tests", () => {
         },
       };
 
-      try {
-        // Pack with Veramo using JWS (from must be managed by veramoAgent)
-        const veramoPacked = await veramoAgent.packDIDCommMessage({
-          packing: "jws",
-          message,
-        });
+      // Pack with Veramo using JWS
+      const veramoPacked = await veramoAgent.packDIDCommMessage({
+        packing: "jws",
+        message,
+      });
 
-        // TAP should be able to unpack Veramo's JWS
-        const tapUnpacked = await tapAgent.unpack(JSON.stringify(veramoPacked));
-        expect(((tapUnpacked.body as any) as any).content).toBe("Hello from Veramo (JWS)!");
-        expect(tapUnpacked.from).toBe(veramoSender.did);
-      } catch (error) {
-        // Veramo requires specific setup for JWS which may not be fully configured
-        console.log("Veramo JWS packing error:", (error as Error).message);
-        // For now, test that we can at least handle the message format
-        expect((error as Error).message).toContain("from");
-      }
+      // TAP unpacks Veramo's JWS
+      const tapUnpacked = await tapAgent.unpack(veramoPacked.message);
+      expect((tapUnpacked.body as any).content).toBe("Hello from Veramo (JWS)!");
+      expect(tapUnpacked.from).toBe(veramoSender.did);
     });
 
     it("should have Veramo unpack messages packed by TAP (JWS)", async () => {
-      // Create a Veramo recipient
       const veramoRecipient = await veramoAgent.didManagerCreate({
         provider: "did:key",
         kms: "local",
         options: { keyType: "Ed25519" },
       });
 
-      // Create and pack a message with TAP
       const tapMessage: DIDCommMessage = {
         id: "tap-jws-001",
         type: "https://didcomm.org/basicmessage/2.0/message",
@@ -279,32 +215,24 @@ describe("TAP-Veramo Interoperability Tests", () => {
 
       const tapPacked = await tapAgent.pack(tapMessage);
 
-      try {
-        // Veramo should be able to unpack TAP's JWS (handle format differences with JSON encoding)
-        const veramoUnpacked = await veramoAgent.unpackDIDCommMessage({
-          message: JSON.stringify(tapPacked),
-        });
+      // Pass just the JWS message string, not the full PackedMessageResult
+      const veramoUnpacked = await veramoAgent.unpackDIDCommMessage({
+        message: tapPacked.message,
+      });
 
-        expect(veramoUnpacked.message.body.content).toBe("Hello from TAP (JWS)!");
-        expect(veramoUnpacked.message.from).toBe(tapAgent.did);
-        expect(veramoUnpacked.metaData.packing).toBe("jws");
-      } catch (error) {
-        // Veramo may not be able to resolve TAP's DID document
-        console.log("Veramo unpacking error:", (error as Error).message);
-        // This is expected as Veramo needs to resolve TAP's DID or handle TAP message format
-        expect((error as Error).message).toMatch(/DID|unable to determine message type|Incorrect format JWS/);
-      }
+      expect(veramoUnpacked.message.body.content).toBe("Hello from TAP (JWS)!");
+      expect(veramoUnpacked.message.from).toBe(tapAgent.did);
+      expect(veramoUnpacked.metaData.packing).toBe("jws");
     });
 
-    it("should unpack messages packed by Veramo (JWE anoncrypt)", async () => {
-      // Create Veramo sender
+    // TAP WASM currently only supports JWS (signed) packing, not JWE (encrypted)
+    it.skip("should unpack messages packed by Veramo (JWE anoncrypt)", async () => {
       const veramoSender = await veramoAgent.didManagerCreate({
         provider: "did:key",
         kms: "local",
         options: { keyType: "Ed25519" },
       });
 
-      // Create a message and pack it with Veramo using anoncrypt (anonymous encryption)
       const message = {
         id: "veramo-jwe-anon-001",
         type: "https://didcomm.org/basicmessage/2.0/message",
@@ -315,34 +243,22 @@ describe("TAP-Veramo Interoperability Tests", () => {
         },
       };
 
-      try {
-        // Pack with Veramo using anoncrypt
-        const veramoPacked = await veramoAgent.packDIDCommMessage({
-          packing: "anoncrypt",
-          message,
-        });
+      const veramoPacked = await veramoAgent.packDIDCommMessage({
+        packing: "anoncrypt",
+        message,
+      });
 
-        // TAP should be able to unpack Veramo's JWE (handle format differences with JSON encoding)
-        const tapUnpacked = await tapAgent.unpack(JSON.stringify(veramoPacked));
-        expect((tapUnpacked.body as any).content).toBe("Hello from Veramo (JWE anoncrypt)!");
-      } catch (error) {
-        // Expected failure - TAP may not fully support Veramo's JWE anoncrypt format yet
-        console.log("TAP JWE anoncrypt unpacking error:", (error as Error).message);
-        expect((error as Error).message).toMatch(/Failed to unpack|from.*field.*managed|invalid|parse/i);
-      }
+      const tapUnpacked = await tapAgent.unpack(veramoPacked.message);
+      expect((tapUnpacked.body as any).content).toBe("Hello from Veramo (JWE anoncrypt)!");
     });
 
-    it("should have Veramo unpack encrypted messages from TAP (if TAP supports JWE)", async () => {
-      // This test depends on whether TAP's WASM layer supports JWE encryption
-      // For now, we'll test that TAP can at least create messages Veramo understands in JWS format
-      
+    it("should have Veramo unpack JWS messages from TAP", async () => {
       const veramoRecipient = await veramoAgent.didManagerCreate({
         provider: "did:key",
         kms: "local",
         options: { keyType: "Ed25519" },
       });
 
-      // Create a message with TAP
       const tapMessage: DIDCommMessage = {
         id: "tap-test-001",
         type: "https://didcomm.org/basicmessage/2.0/message",
@@ -354,35 +270,21 @@ describe("TAP-Veramo Interoperability Tests", () => {
         },
       };
 
-      // Pack with TAP (will use JWS since that's what TAP currently supports)
+      // TAP produces JWS format
       const tapPacked = await tapAgent.pack(tapMessage);
 
-      // Check if it's JWS or JWE by parsing the message
-      try {
-        const parsedMessage = JSON.parse(tapPacked.message);
-        if (parsedMessage.payload && parsedMessage.signatures) {
-          // JWS format - Veramo should be able to unpack it
-          const veramoUnpacked = await veramoAgent.unpackDIDCommMessage({
-            message: tapPacked.message,
-          });
-          expect(veramoUnpacked.message.body.content).toBe("Testing TAP to Veramo");
-          expect(veramoUnpacked.metaData.packing).toBe("jws");
-        } else if (parsedMessage.protected && parsedMessage.ciphertext) {
-          // JWE format - if TAP supports it
-          const veramoUnpacked = await veramoAgent.unpackDIDCommMessage({
-            message: tapPacked.message,
-          });
-          expect(veramoUnpacked.message.body.content).toBe("Testing TAP to Veramo");
-          expect(["authcrypt", "anoncrypt"]).toContain(veramoUnpacked.metaData.packing);
-        } else {
-          // Unknown format
-          console.log("Unknown message format");
-        }
-      } catch (error) {
-        // Expected failure due to format differences or key issues
-        console.log("Veramo unpacking error:", (error as Error).message);
-        expect((error as Error).message).toMatch(/DID document.*not.*located|key.*not.*found|unable to determine message type|Incorrect format|parse/i);
-      }
+      // Verify Flattened JWS structure
+      const parsedMessage = JSON.parse(tapPacked.message);
+      expect(parsedMessage.payload).toBeDefined();
+      expect(parsedMessage.protected).toBeDefined();
+      expect(parsedMessage.signature).toBeDefined();
+
+      // Veramo unpacks TAP's JWS
+      const veramoUnpacked = await veramoAgent.unpackDIDCommMessage({
+        message: tapPacked.message,
+      });
+      expect(veramoUnpacked.message.body.content).toBe("Testing TAP to Veramo");
+      expect(veramoUnpacked.metaData.packing).toBe("jws");
     });
 
     it("should handle trust ping messages bidirectionally", async () => {
@@ -392,7 +294,7 @@ describe("TAP-Veramo Interoperability Tests", () => {
         options: { keyType: "Ed25519" },
       });
 
-      // 1. Veramo creates and packs a trust ping
+      // 1. Veramo packs a trust ping
       const veramoPing = {
         id: "veramo-ping-001",
         type: "https://didcomm.org/trust-ping/2.0/ping",
@@ -403,45 +305,38 @@ describe("TAP-Veramo Interoperability Tests", () => {
         },
       };
 
-      try {
-        const veramoPackedPing = await veramoAgent.packDIDCommMessage({
-          packing: "jws",
-          message: veramoPing,
-        });
+      const veramoPackedPing = await veramoAgent.packDIDCommMessage({
+        packing: "jws",
+        message: veramoPing,
+      });
 
-        // 2. TAP unpacks Veramo's ping (handle format differences with JSON encoding)
-        const tapUnpackedPing = await tapAgent.unpack(JSON.stringify(veramoPackedPing));
-        expect(tapUnpackedPing.type).toBe("https://didcomm.org/trust-ping/2.0/ping");
-        expect((tapUnpackedPing.body as any).response_requested).toBe(true);
+      // 2. TAP unpacks Veramo's ping
+      const tapUnpackedPing = await tapAgent.unpack(veramoPackedPing.message);
+      expect(tapUnpackedPing.type).toBe("https://didcomm.org/trust-ping/2.0/ping");
+      expect((tapUnpackedPing.body as any).response_requested).toBe(true);
 
-        // 3. TAP creates and packs a ping response
-        const tapPingResponse: DIDCommMessage = {
-          id: "tap-ping-response-001",
-          type: "https://didcomm.org/trust-ping/2.0/ping-response",
-          from: tapAgent.did,
-          to: [veramoIdentifier.did as DID],
-          thid: veramoPing.id, // Thread reference to original ping
-          created_time: Date.now(),
-          body: {},
-        };
+      // 3. TAP packs a ping response
+      const tapPingResponse: DIDCommMessage = {
+        id: "tap-ping-response-001",
+        type: "https://didcomm.org/trust-ping/2.0/ping-response",
+        from: tapAgent.did,
+        to: [veramoIdentifier.did as DID],
+        thid: veramoPing.id,
+        created_time: Date.now(),
+        body: {},
+      };
 
-        const tapPackedResponse = await tapAgent.pack(tapPingResponse);
+      const tapPackedResponse = await tapAgent.pack(tapPingResponse);
 
-        // 4. Veramo unpacks TAP's response (handle format differences with JSON encoding)
-        const veramoUnpackedResponse = await veramoAgent.unpackDIDCommMessage({
-          message: JSON.stringify(tapPackedResponse),
-        });
+      // 4. Veramo unpacks TAP's response
+      const veramoUnpackedResponse = await veramoAgent.unpackDIDCommMessage({
+        message: tapPackedResponse.message,
+      });
 
-        expect(veramoUnpackedResponse.message.type).toBe(
-          "https://didcomm.org/trust-ping/2.0/ping-response",
-        );
-        expect(veramoUnpackedResponse.message.thid).toBe(veramoPing.id);
-      } catch (error) {
-        // Veramo requires the `from` DID to be managed by the agent for packing
-        // This is expected behavior - log and skip for now
-        console.log("Veramo bidirectional test error:", (error as Error).message);
-        expect((error as Error).message).toMatch(/from.*field.*managed|DID document.*not.*located/);
-      }
+      expect(veramoUnpackedResponse.message.type).toBe(
+        "https://didcomm.org/trust-ping/2.0/ping-response",
+      );
+      expect(veramoUnpackedResponse.message.thid).toBe(veramoPing.id);
     });
   });
 
@@ -453,7 +348,6 @@ describe("TAP-Veramo Interoperability Tests", () => {
         options: { keyType: "Ed25519" },
       });
 
-      // Create TAP Transfer message
       const transferMessage = await createTransferMessage({
         from: tapAgent.did,
         to: [veramoRecipient.did as DID],
@@ -472,26 +366,18 @@ describe("TAP-Veramo Interoperability Tests", () => {
         memo: "Payment for services rendered",
       });
 
-      // Pack with TAP
       const packed = await tapAgent.pack(transferMessage);
 
-      try {
-        // Veramo should be able to unpack TAP Transfer messages
-        const veramoUnpacked = await veramoAgent.unpackDIDCommMessage({
-          message: JSON.stringify(packed),
-        });
+      // Pass just the JWS message string to Veramo
+      const veramoUnpacked = await veramoAgent.unpackDIDCommMessage({
+        message: packed.message,
+      });
 
-        // Verify Veramo correctly unpacked the TAP message
-        expect(veramoUnpacked.message.type).toBe("https://tap.rsvp/schema/1.0#Transfer");
-        expect(veramoUnpacked.message.body.amount).toBe("100.50");
-        expect(veramoUnpacked.message.body.originator["@id"]).toBe(tapAgent.did);
-        expect(veramoUnpacked.message.body.beneficiary["@id"]).toBe(veramoRecipient.did);
-        expect(veramoUnpacked.metaData.packing).toBe("jws");
-      } catch (error) {
-        // Expected failure due to key ID format differences
-        console.log("Veramo Transfer unpacking error:", (error as Error).message);
-        expect((error as Error).message).toMatch(/DID document.*not.*located|key.*not.*found|unable to determine message type|Incorrect format JWS/i);
-      }
+      expect(veramoUnpacked.message.type).toBe("https://tap.rsvp/schema/1.0#Transfer");
+      expect(veramoUnpacked.message.body.amount).toBe("100.50");
+      expect(veramoUnpacked.message.body.originator["@id"]).toBe(tapAgent.did);
+      expect(veramoUnpacked.message.body.beneficiary["@id"]).toBe(veramoRecipient.did);
+      expect(veramoUnpacked.metaData.packing).toBe("jws");
     });
 
     it("should have Veramo handle TAP Payment messages with invoices", async () => {
@@ -501,7 +387,6 @@ describe("TAP-Veramo Interoperability Tests", () => {
         options: { keyType: "Ed25519" },
       });
 
-      // Create TAP Payment message
       const paymentMessage = await createPaymentMessage({
         from: tapAgent.did,
         to: [veramoMerchant.did as DID],
@@ -536,25 +421,17 @@ describe("TAP-Veramo Interoperability Tests", () => {
         },
       });
 
-      // Pack with TAP
       const packed = await tapAgent.pack(paymentMessage);
 
-      try {
-        // Veramo should be able to unpack TAP Payment messages
-        const veramoUnpacked = await veramoAgent.unpackDIDCommMessage({
-          message: JSON.stringify(packed),
-        });
+      const veramoUnpacked = await veramoAgent.unpackDIDCommMessage({
+        message: packed.message,
+      });
 
-        expect(veramoUnpacked.message.type).toBe("https://tap.rsvp/schema/1.0#Payment");
-        expect(veramoUnpacked.message.body.amount).toBe("249.99");
-        expect(veramoUnpacked.message.body.invoice.invoiceNumber).toBe("INV-2024-12345");
-        expect(veramoUnpacked.message.body.invoice.items).toHaveLength(3);
-        expect(veramoUnpacked.message.body.merchant["@id"]).toBe(veramoMerchant.did);
-      } catch (error) {
-        // Expected failure due to key ID format differences
-        console.log("Veramo Payment unpacking error:", (error as Error).message);
-        expect((error as Error).message).toMatch(/DID document.*not.*located|key.*not.*found|unable to determine message type|Incorrect format JWS/i);
-      }
+      expect(veramoUnpacked.message.type).toBe("https://tap.rsvp/schema/1.0#Payment");
+      expect(veramoUnpacked.message.body.amount).toBe("249.99");
+      expect(veramoUnpacked.message.body.invoice.invoiceNumber).toBe("INV-2024-12345");
+      expect(veramoUnpacked.message.body.invoice.items).toHaveLength(3);
+      expect(veramoUnpacked.message.body.merchant["@id"]).toBe(veramoMerchant.did);
     });
 
     it("should have bidirectional TAP message exchange with Veramo", async () => {
@@ -564,7 +441,7 @@ describe("TAP-Veramo Interoperability Tests", () => {
         options: { keyType: "Ed25519" },
       });
 
-      // 1. TAP creates and packs a Connect message
+      // 1. TAP packs a Connect message
       const connectMessage = await createConnectMessage({
         from: tapAgent.did,
         to: [veramoCounterparty.did as DID],
@@ -596,43 +473,37 @@ describe("TAP-Veramo Interoperability Tests", () => {
 
       const tapPacked = await tapAgent.pack(connectMessage);
 
-      try {
-        // 2. Veramo unpacks TAP's Connect message (handle format differences with JSON encoding)
-        const veramoUnpacked = await veramoAgent.unpackDIDCommMessage({
-          message: JSON.stringify(tapPacked),
-        });
+      // 2. Veramo unpacks TAP's Connect message
+      const veramoUnpacked = await veramoAgent.unpackDIDCommMessage({
+        message: tapPacked.message,
+      });
 
-        expect(veramoUnpacked.message.type).toBe("https://tap.rsvp/schema/1.0#Connect");
-        expect(veramoUnpacked.message.body.constraints.asset_types).toHaveLength(3);
+      expect(veramoUnpacked.message.type).toBe("https://tap.rsvp/schema/1.0#Connect");
+      expect(veramoUnpacked.message.body.constraints.asset_types).toHaveLength(3);
 
-        // 3. Veramo creates a response (could be an Authorize message)
-        const veramoResponse = {
-          id: "veramo-auth-001",
-          type: "https://tap.rsvp/schema/1.0#Authorize",
-          from: veramoCounterparty.did,
-          to: [tapAgent.did],
-          thid: connectMessage.id,
-          body: {
-            "@context": "https://tap.rsvp/schema/1.0",
-            "@type": "Authorize",
-            settlementAddress: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb7",
-          },
-        };
+      // 3. Veramo packs an Authorize response
+      const veramoResponse = {
+        id: "veramo-auth-001",
+        type: "https://tap.rsvp/schema/1.0#Authorize",
+        from: veramoCounterparty.did,
+        to: [tapAgent.did],
+        thid: connectMessage.id,
+        body: {
+          "@context": "https://tap.rsvp/schema/1.0",
+          "@type": "Authorize",
+          settlementAddress: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb7",
+        },
+      };
 
-        const veramoPackedResponse = await veramoAgent.packDIDCommMessage({
-          packing: "jws",
-          message: veramoResponse,
-        });
+      const veramoPackedResponse = await veramoAgent.packDIDCommMessage({
+        packing: "jws",
+        message: veramoResponse,
+      });
 
-        // 4. TAP unpacks Veramo's response (handle format differences with JSON encoding)
-        const tapUnpackedResponse = await tapAgent.unpack(JSON.stringify(veramoPackedResponse));
-        expect(tapUnpackedResponse.type).toBe("https://tap.rsvp/schema/1.0#Authorize");
-        expect(tapUnpackedResponse.thid).toBe(connectMessage.id);
-      } catch (error) {
-        // Expected failure due to key ID format differences or agent management issues
-        console.log("Veramo bidirectional Connect test error:", (error as Error).message);
-        expect((error as Error).message).toMatch(/DID document.*not.*located|from.*field.*managed|key.*not.*found|unable to determine message type|Incorrect format JWS/i);
-      }
+      // 4. TAP unpacks Veramo's response
+      const tapUnpackedResponse = await tapAgent.unpack(veramoPackedResponse.message);
+      expect(tapUnpackedResponse.type).toBe("https://tap.rsvp/schema/1.0#Authorize");
+      expect(tapUnpackedResponse.thid).toBe(connectMessage.id);
     });
   });
 

--- a/tap-ts/tests/veramo-integration.test.ts
+++ b/tap-ts/tests/veramo-integration.test.ts
@@ -225,8 +225,7 @@ describe("TAP-Veramo Interoperability Tests", () => {
       expect(veramoUnpacked.metaData.packing).toBe("jws");
     });
 
-    // TAP WASM currently only supports JWS (signed) packing, not JWE (encrypted)
-    it.skip("should unpack messages packed by Veramo (JWE anoncrypt)", async () => {
+    it("should unpack messages packed by Veramo (JWE anoncrypt)", async () => {
       const veramoSender = await veramoAgent.didManagerCreate({
         provider: "did:key",
         kms: "local",

--- a/tap-wasm/Cargo.toml
+++ b/tap-wasm/Cargo.toml
@@ -56,6 +56,9 @@ name = "wasm_binding_benchmark"
 harness = false
 required-features = []
 
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
+
 # Optimize for size
 [profile.release]
 opt-level = "z"   # Optimize for size

--- a/tap-wasm/tests/message_operations_tests.rs
+++ b/tap-wasm/tests/message_operations_tests.rs
@@ -50,8 +50,8 @@ async fn test_pack_message_delegation() {
         "JWS should have payload field"
     );
     assert!(
-        parsed.get("signatures").is_some(),
-        "JWS should have signatures field"
+        parsed.get("signature").is_some() || parsed.get("signatures").is_some(),
+        "JWS should have signature or signatures field"
     );
 }
 


### PR DESCRIPTION
## Summary
This PR updates the TAP agent to use Flattened JWS (JSON Web Signature) serialization format instead of General JWS format, enabling proper interoperability with Veramo's DIDComm implementation. The changes include custom serialization logic, flexible base64 decoding, and improved DID resolution for verification.

## Key Changes

### Message Format (Flattened JWS)
- **Custom JWS serialization**: Implemented `Serialize` and `Deserialize` traits for the `Jws` struct to support both formats:
  - Single signature: Flattened format with `payload`, `protected`, and `signature` at top level
  - Multiple signatures: General format with `payload` and `signatures` array
- **Flexible base64 decoding**: Added `base64_decode_flexible()` function that accepts standard base64, base64url with/without padding to handle different encoding schemes from Veramo
- Updated all JWS encoding to use `URL_SAFE_NO_PAD` (base64url without padding) per RFC 7515

### DID Resolution Improvements
- Enhanced `resolve_verification_key()` in both `DefaultKeyManager` and `AgentKeyManager` to directly resolve `did:key` DIDs without requiring external resolver setup
- Added caching of resolved verification keys for performance
- Improved error handling for key resolution failures

### Test Updates
- Updated integration tests to expect Flattened JWS structure (`protected`/`signature` fields instead of `signatures` array)
- Removed try-catch error handling from interoperability tests - they now expect successful message exchange
- Simplified test assertions to work with the new format
- Marked JWE (encrypted) tests as skipped since TAP WASM currently only supports JWS
- Updated Veramo integration tests to use built-in memory stores (`MemoryDIDStore`, `MemoryKeyStore`, `MemoryPrivateKeyStore`) imported from `@veramo/did-manager` and `@veramo/key-manager`

### Build Configuration
- Added `wasm-opt = false` to wasm-pack release profile in `Cargo.toml` to prevent optimization issues

## Implementation Details
- The custom JWS deserializer intelligently detects format (General vs Flattened) and normalizes to internal representation
- All base64 decoding now uses the flexible function to handle both standard and URL-safe variants
- DID resolution for `did:key` is now self-contained, reducing external dependencies during message verification
- Message packing/unpacking logic updated to handle both JWS formats transparently

https://claude.ai/code/session_01WWHiooMRiBBdSiQQwWqQGt