### PR TITLE
Add external secret helper, JWS flattening, X25519 JWE support, and security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+#### External Secret Helper for Key Management (tap-agent, tap-cli, tap-http, tap-mcp)
+- Git-like secret helper pattern for retrieving private keys from external stores (HashiCorp Vault, AWS KMS, 1Password)
+- `get_private_key(did)` method on `AgentKeyManager` and `KeyManager` trait
+- `secret_helper` module with `SecretHelperConfig` and `discover_agent_dids`
+- `TapAgent::from_secret_helper()` factory method for external key provisioning
+- `--secret-helper` / `TAP_SECRET_HELPER` flag added to tap-cli, tap-http, and tap-mcp
+
+#### Flattened JWS Serialization for Veramo Compatibility (tap-agent)
+- Default to Flattened JWS serialization for single signatures per RFC 7515
+- Accept both General and Flattened JWS formats on deserialization
+- `base64_decode_flexible()` helper accepting all Base64 variants (standard, URL-safe, padded/unpadded)
+- `did:key` resolution in `resolve_verification_key` for cross-agent signature verification
+
+#### X25519 JWE Anoncrypt Support (tap-agent)
+- X25519 ECDH key agreement via `x25519-dalek` for Veramo JWE interoperability
+- Support X25519 ephemeral public keys in `unwrap_jwe` alongside existing P-256
+- Optional `apv`/`apu` fields in `JweProtected` (Veramo omits them)
+- Match JWE recipients by DID prefix for X25519 key agreement key IDs
+
+### Changed
+- JWS encoding switched from standard Base64 to Base64URL (no padding) per RFC 7515
+
+### Fixed
+- External decision process tool responses now correctly returned to caller
+- Panicking `unwrap` on database deserialization replaced with proper error handling
+- Panic on missing home directory replaced with graceful error
+- Hand-rolled URL encoding replaced with `urlencoding` crate
+
+### Security
+- **Critical**: Fix SQL injection in MCP database tools via table name interpolation
+- **High**: Add `PRAGMA query_only=ON` to prevent SQL read-only filter bypass
+- **High**: Sanitize internal error details leaked to HTTP clients
+- **High**: Add request body size limit to tap-http
+- **High**: Add rate limiting to unbounded agent creation endpoint
+- **High**: Validate NaN/Infinity in financial amount fields (Transfer, Payment, Settle)
+- **Medium**: Fix fail-open authorization validator
+- **Medium**: Prevent DID path traversal
+- **Medium**: Fix LIKE pattern injection in database queries
+- **Low**: Replace hand-rolled URL encoding with `urlencoding` crate
+- Update `happy-dom` to v20 to fix critical VM escape vulnerability (tap-ts)
+
 ## [0.6.0] - 2026-02-22
 
 ### Added

--- a/tap-ts/CHANGELOG.md
+++ b/tap-ts/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to @taprsvp/agent will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- JWS serialization switched from General to Flattened format for single signatures (Veramo compatibility)
+- JWS encoding switched from standard Base64 to Base64URL (no padding) per RFC 7515
+- Tests updated to expect Flattened JWS format
+
+### Added
+- X25519 JWE anoncrypt support for Veramo interoperability
+- Flexible Base64 decoding accepting standard, URL-safe, padded and unpadded variants
+
+### Security
+- Update `happy-dom` to v20 to fix critical VM escape vulnerability
+
 ## [0.6.0] - 2026-02-22
 
 ### Added


### PR DESCRIPTION
## Summary

This PR introduces significant improvements to key management, cryptographic interoperability, and security across the TAP agent ecosystem. The changes enable external secret provisioning via git-like helpers, improve Veramo compatibility through JWS format standardization, add X25519 support for JWE operations, and address multiple security vulnerabilities.

## Key Changes

### External Secret Helper for Key Management
- Implemented git-like secret helper pattern for retrieving private keys from external stores (HashiCorp Vault, AWS KMS, 1Password)
- Added `get_private_key(did)` method to `AgentKeyManager` and `KeyManager` trait
- Created `secret_helper` module with `SecretHelperConfig` and `discover_agent_dids` functionality
- Added `TapAgent::from_secret_helper()` factory method for external key provisioning
- Integrated `--secret-helper` / `TAP_SECRET_HELPER` flag across tap-cli, tap-http, and tap-mcp

### Flattened JWS Serialization for Veramo Compatibility
- Switched default JWS serialization from General to Flattened format for single signatures (RFC 7515 compliant)
- Implemented flexible deserialization accepting both General and Flattened JWS formats
- Added `base64_decode_flexible()` helper supporting all Base64 variants (standard, URL-safe, padded/unpadded)
- Implemented `did:key` resolution in `resolve_verification_key` for cross-agent signature verification

### X25519 JWE Anoncrypt Support
- Added X25519 ECDH key agreement via `x25519-dalek` for Veramo JWE interoperability
- Implemented support for X25519 ephemeral public keys in `unwrap_jwe` alongside existing P-256
- Made `apv`/`apu` fields optional in `JweProtected` (Veramo omits them)
- Added DID prefix matching for X25519 key agreement key IDs in JWE recipients

### Security Fixes
- **Critical**: Fixed SQL injection in MCP database tools via table name interpolation
- **High**: Added `PRAGMA query_only=ON` to prevent SQL read-only filter bypass
- **High**: Sanitized internal error details leaked to HTTP clients
- **High**: Added request body size limit to tap-http
- **High**: Added rate limiting to unbounded agent creation endpoint
- **High**: Added validation for NaN/Infinity in financial amount fields (Transfer, Payment, Settle)
- **Medium**: Fixed fail-open authorization validator
- **Medium**: Prevented DID path traversal
- **Medium**: Fixed LIKE pattern injection in database queries
- **Low**: Replaced hand-rolled URL encoding with `urlencoding` crate
- Updated `happy-dom` to v20 to fix critical VM escape vulnerability (tap-ts)

### Bug Fixes
- External decision process tool responses now correctly returned to caller
- Replaced panicking `unwrap` on database deserialization with proper error handling
- Replaced panic on missing home directory with graceful error handling
- Replaced hand-rolled URL encoding with `urlencoding` crate

### Encoding Changes
- JWS encoding switched from standard Base64 to Base64URL (no padding) per RFC 7515

https://claude.ai/code/session_01U5pusfFsLrcwHqZjFhfb8L