### PR TITLE
Always rebuild WASM before build and test

### DIFF
--- a/tap-ts/package.json
+++ b/tap-ts/package.json
@@ -46,8 +46,10 @@
     "node": ">=20"
   },
   "scripts": {
-    "build": "tsc --project tsconfig.build.json && vite build",
+    "build:wasm": "./scripts/build-wasm.sh",
+    "build": "npm run build:wasm && tsc --project tsconfig.build.json && vite build",
     "dev": "vite",
+    "pretest": "npm run build:wasm",
     "test": "vitest --no-watch",
     "test:watch": "vitest",
     "test:coverage": "vitest --coverage",

--- a/tap-ts/scripts/build-wasm.sh
+++ b/tap-ts/scripts/build-wasm.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TS_DIR="$(dirname "$SCRIPT_DIR")"
+WASM_DIR="$TS_DIR/../tap-wasm"
+
+# Check if wasm-pack is installed
+if ! command -v wasm-pack &> /dev/null; then
+  echo "Error: wasm-pack is not installed."
+  echo "Install with: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh"
+  exit 1
+fi
+
+# Build WASM
+echo "Building WASM..."
+cd "$WASM_DIR"
+wasm-pack build --target web --out-dir pkg --release
+
+# Copy WASM files to tap-ts/wasm/
+echo "Copying WASM files to tap-ts/wasm/..."
+rm -rf "$TS_DIR/wasm"
+mkdir -p "$TS_DIR/wasm"
+cp pkg/tap_wasm_bg.wasm "$TS_DIR/wasm/"
+cp pkg/tap_wasm_bg.wasm.d.ts "$TS_DIR/wasm/" 2>/dev/null || true
+cp pkg/tap_wasm.js "$TS_DIR/wasm/"
+cp pkg/tap_wasm.d.ts "$TS_DIR/wasm/"
+
+echo "WASM build complete."

--- a/tap-ts/scripts/prepare-publish.sh
+++ b/tap-ts/scripts/prepare-publish.sh
@@ -3,37 +3,8 @@ set -e
 
 echo "Preparing @taprsvp/agent for publishing..."
 
-# Build WASM if needed
-if [ ! -f "../tap-wasm/pkg/tap_wasm_bg.wasm" ]; then
-  echo "WASM files not found. Building WASM..."
-  
-  # Check if wasm-pack is installed
-  if ! command -v wasm-pack &> /dev/null; then
-    echo "Error: wasm-pack is not installed."
-    echo "Please install it with: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh"
-    exit 1
-  fi
-  
-  cd ../tap-wasm
-  wasm-pack build --target web --out-dir pkg --release
-  cd ../tap-ts
-fi
-
-# Clean and create wasm directory
-rm -rf wasm
-mkdir -p wasm
-
-# Copy WASM files
-echo "Copying WASM files..."
-cp ../tap-wasm/pkg/tap_wasm_bg.wasm wasm/
-cp ../tap-wasm/pkg/tap_wasm_bg.wasm.d.ts wasm/ 2>/dev/null || true
-cp ../tap-wasm/pkg/tap_wasm.js wasm/
-cp ../tap-wasm/pkg/tap_wasm.d.ts wasm/
-
-# Update imports in the copied files to use relative paths
-echo "Updating import paths..."
-sed -i.bak "s|'./tap_wasm_bg.wasm'|'./tap_wasm_bg.wasm'|g" wasm/tap_wasm.js
-rm wasm/*.bak 2>/dev/null || true
+# Build WASM and copy files
+npm run build:wasm
 
 # Build TypeScript
 echo "Building TypeScript..."


### PR DESCRIPTION
## Summary
- Add `build:wasm` script that always rebuilds WASM via `wasm-pack` and copies output to `tap-ts/wasm/`
- Add `pretest` hook so `npm test` always gets fresh WASM binaries
- Chain `build:wasm` into `npm run build` so builds always use current Rust code
- Simplify `prepare-publish.sh` to delegate WASM building to the new script

Fixes 27 test failures caused by stale WASM binaries after the Flattened JWS serialization change (`a3d9306`).

## Test plan
- [x] `npm run build` rebuilds WASM and compiles TypeScript
- [x] `npm test` passes all 134 tests (pretest rebuilds WASM)
- [x] `cargo fmt --all --check` passes
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --release` passes
- [x] `RUSTFLAGS="-D warnings" cargo test --workspace --all-targets --release` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)