### PR TITLE
tap-ts: release @taprsvp/agent 0.7.0

### DIFF
--- a/tap-ts/package-lock.json
+++ b/tap-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@taprsvp/agent",
-  "version": "0.7.0-SNAPSHOT",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@taprsvp/agent",
-      "version": "0.7.0-SNAPSHOT",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@taprsvp/types": "^2.1.0"
@@ -40,7 +40,10 @@
       }
     },
     "../tap-wasm/pkg": {
-      "dev": true
+      "name": "tap-wasm",
+      "version": "0.7.0",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",

--- a/tap-ts/package.json
+++ b/tap-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@taprsvp/agent",
-  "version": "0.7.0-SNAPSHOT",
+  "version": "0.7.0",
   "type": "module",
   "description": "TypeScript wrapper for TAP WASM Agent - Browser-optimized message packing/unpacking with flexible key management",
   "keywords": [


### PR DESCRIPTION
## Summary

Drops the `-SNAPSHOT` suffix on `tap-ts/package.json` to match the v0.7.0 npm release of `@taprsvp/agent` (already published).

- npm: https://www.npmjs.com/package/@taprsvp/agent/v/0.7.0
- Companion to the v0.7.0 crates.io release ([release notes](https://github.com/TransactionAuthorizationProtocol/tap-rs/releases/tag/v0.7.0))

## Test plan

- [x] @taprsvp/agent@0.7.0 already pushed to npm successfully
- [x] `npm view @taprsvp/agent version` returns 0.7.0
- [x] `npm test` 134/134 pass on this checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)